### PR TITLE
move music display

### DIFF
--- a/resources/skins/default/720p/script-python-slideshow.xml
+++ b/resources/skins/default/720p/script-python-slideshow.xml
@@ -114,7 +114,7 @@
 			</control>
 			<control type="group">
 				<posx>20</posx>
-				<posy>20</posy>
+				<posy>562</posy>
 				<animation effect="fade" start="80" end="80" time="0" condition="true">Conditional</animation>
 				<visible>Player.HasAudio + StringCompare(Window.Property(SlideView.Music),show)</visible>
 				<control type="image">


### PR DESCRIPTION
As I was using this I thought the placement of the music display made more sense in the bottom than the top. It seemed to cut off the "focus" of the photo by extending too far into the top when in it's original position. I tried to line up the bottom display with the picture date so everything will be in line. 