### PR TITLE
Hacked bug fix for when we have repeated text in display additional p…

### DIFF
--- a/resources/lib/gui.py
+++ b/resources/lib/gui.py
@@ -239,7 +239,9 @@ class Screensaver(xbmcgui.WindowXMLDialog):
                     self.datelabel.setVisible(False)
                 # display iptc data if we have any
                 if iptc_ti or iptc_de or iptc_ke:
-                    self.textbox.setText(title + '[CR]' + description + '[CR]' + keywords)
+                    self.textbox.setText(
+                        '[CR]'.join([title, keywords] if title == description
+                                    else [title, description, keywords]))
                     self.textbox.setVisible(True)
                 else:
                     self.textbox.setVisible(False)


### PR DESCRIPTION
…icture tags when title == description

We sometimes end up with an overlay of the form e.g.:

Hobbiton, near Matamata, North Island, New Zealand
Hobbiton, near Matamata, North Island, New Zealand

This is caused when we have a file with xmptags where the values for title and description are populated and equal.