### PR TITLE
add notification to remote image service

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="screensaver.picture.slideshow" name="Picture Slideshow Screensaver" version="4.2.1" provider-name="Team Kodi">
+<addon id="screensaver.picture.slideshow" name="Picture Slideshow Screensaver" version="4.2.2" provider-name="Team Kodi">
 	<requires>
 		<import addon="xbmc.python" version="2.25.0"/>
 		<import addon="script.module.elementtree" version="1.2.8" />

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+v4.2.2
+- add notification to remote image service
+
 v4.2.1
 - cosmetics
 

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -122,3 +122,11 @@ msgstr ""
 msgctxt "#30029"
 msgid "Display background picture"
 msgstr ""
+
+msgctxt "#30030"
+msgid "Notify remote service"
+msgstr ""
+
+msgctxt "#30031"
+msgid "Remote service POST URL"
+msgstr ""

--- a/resources/lib/gui.py
+++ b/resources/lib/gui.py
@@ -14,6 +14,7 @@
 # *  http://www.gnu.org/copyleft/gpl.html
 
 import random, copy, threading
+import urllib2
 import xbmcgui, xbmcaddon
 import EXIFvfs
 from iptcinfovfs import IPTCInfo
@@ -96,6 +97,8 @@ class Screensaver(xbmcgui.WindowXMLDialog):
         self.slideshow_iptc   = ADDON.getSetting('iptc')
         self.slideshow_music  = ADDON.getSetting('music')
         self.slideshow_bg     = ADDON.getSetting('background')
+        self.slideshow_notify = ADDON.getSetting('notify')
+        self.slideshow_posturl = ADDON.getSetting('posturl')
         # select which image controls from the xml we are going to use
         if self.slideshow_scale == 'false':
             self.image1 = self.getControl(1)
@@ -281,6 +284,12 @@ class Screensaver(xbmcgui.WindowXMLDialog):
                     order = [1,2]
                 # slideshow time in secs (we already slept for 1 second)
                 count = self.slideshow_time - 1
+                # notify remote service we are displaying this image
+                if self.slideshow_notify == 'true':
+                    try:
+                        urllib2.urlopen(url=self.slideshow_posturl, data=img[0]).read()
+                    except Exception:
+                        pass
                 # display the image for the specified amount of time
                 while (not self.Monitor.abortRequested()) and (not self.stop) and count > 0:
                     count -= 1

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -19,5 +19,8 @@
 		<setting label="30021" type="bool" id="date" default="false"/>
 		<setting label="30022" type="bool" id="iptc" default="false"/>
 		<setting label="30023" type="bool" id="music" default="false"/>
+		<setting type="sep"/>
+		<setting label="30030" type="bool" id="notify" default="false"/>
+        <setting label="30031" type="text" id="posturl" default="http://127.0.0.1:8000/artnow"/>
 	</category>
 </settings>


### PR DESCRIPTION
This patch adds the ability to notify an external image service about the currently displayed image.
This enables integration with 3rd party systems such as an Amazon Echo skill. It only sends
the image path and is designed to fail gracefully when the remote server is not present. 

[forum post](https://forum.kodi.tv/showthread.php?tid=154032&pid=2618126#pid2618126)